### PR TITLE
Sort outline view alphabetically based on setting

### DIFF
--- a/outline.py
+++ b/outline.py
@@ -19,6 +19,8 @@ class OutlineCloseSidebarCommand(WindowCommand):
 class OutlineRefreshCommand(TextCommand):
 	def run(self, edit, symlist=None, symkeys=None, path=None, to_expand=None, toggle=None):
 		self.view.erase(edit, Region(0, self.view.size()))
+		if self.view.settings().get('outline_alphabetical'):
+			symlist, symkeys = (list(t) for t in zip(*sorted(zip(symlist, symkeys))))
 		self.view.insert(edit, 0, "\n".join(symlist))
 		self.view.settings().set('symlist', symlist)
 		self.view.settings().set('symkeys', symkeys)

--- a/outline.sublime-settings
+++ b/outline.sublime-settings
@@ -44,6 +44,10 @@
   // false: a new view is created.
   "outline_reuse_view": true,
 
+  // true: Enable alphabetical sort in output.
+  // false: default because of losing parent dependences.
+  "outline_alphabetical": false,
+
   // How should be positioned the Browse Mode view opened when jumping
   // "left": the default, open the view on the left
   // "right": open the view on the right


### PR DESCRIPTION
Improved over PR #13 by @dabro666 because it's only a two-line change in outline.py. Settings value `outline_alphabetical` preserved from dabro666 PR with minor spelling correction.

Request and recommend using this PR rather than #13, but thanks to dabro666 for the effort.

Ref #6